### PR TITLE
Rewrite to work with new omero-web role

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ services:
   - docker
 
 install:
-  - pip install ansible docker 'molecule<1.22'
+  - pip install ome-ansible-molecule-dependencies
 
 script:
   - molecule test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,29 +1,15 @@
 ---
+sudo: required
 language: python
-python: "2.7"
 
-# Use the new container infrastructure
-sudo: false
-
-# Install ansible
-addons:
-  apt:
-    packages:
-    - python-pip
+services:
+  - docker
 
 install:
-  # Install ansible
-  - pip install ansible
-
-  # Check ansible version
-  - ansible --version
-
-  # Create ansible.cfg with correct roles_path
-  - printf '[defaults]\nroles_path=../' >ansible.cfg
+  - pip install ansible docker 'molecule<1.22'
 
 script:
-  # Basic role syntax check
-  - ansible-playbook tests/test.yml -i tests/inventory --syntax-check
+  - molecule test
 
 notifications:
   webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ Role Variables
 --------------
 
 All variables are optional:
-- `omero_web_apps_name`: List of web application names to be appended to `omero.web.apps`
-- `omero_web_apps_package`: List of pip installable packages
+- `omero_web_apps_names`: List of web application names to be appended to `omero.web.apps`
+- `omero_web_apps_packages`: List of pip installable packages
 - `omero_web_apps_top_links`: Lists of top link dictionaries to be appended to `omero.web.ui.top_links`, of the form:
   - `label`: Label
   - `link`: URL or a dict

--- a/README.md
+++ b/README.md
@@ -1,34 +1,31 @@
-OMERO Web Applications
-======================
+OMERO Web Applications and Configuration
+========================================
 
-Install OMERO.web plugins.
+Additional OMERO.web configuration.
+This is primarily aimed to help with the configuration of OMERO.web applications/plugins, but can also be used to manage standard OMERO.web configuration properties.
+This role only works with OMERO.web 5.3+ due to changes in the configuration handling.
 
 
 Dependencies
 ------------
 
-Assumes OMERO.web has already been installed with OMERO.server.
-
-This also assumes the following variables from `roles/omero-server` are defined:
-- `omero_serverdir`
-- `omero_server_symlink`
-- `omero_system_user`
-- `omero_systemd_setup`
+Assumes OMERO.web has already been installed in the standard location using the `openmicroscopy.omero-web` role.
 
 
 Role Variables
 --------------
 
-All variables are optional, see `defaults/main.yml` for the full list
-
-- `omero_web_app_packages`: List of pip installable packages or URLs
-- `omero_web_apps_add`: List of web application names to be included in `omero.web.apps`
-- `omero_web_app_add_top_links`: Dictionary of lists to be included in `omero.web.ui.top_links`.
-  This must be a YAML object, which will be auto-converted to JSON.
-- `omero_web_app_add_top_links`: Lists of top link dictionaries to be included in `omero.web.ui.top_links`, of the form:
+All variables are optional:
+- `omero_web_apps_name`: List of web application names to be appended to `omero.web.apps`
+- `omero_web_apps_package`: List of pip installable packages
+- `omero_web_apps_top_links`: Lists of top link dictionaries to be appended to `omero.web.ui.top_links`, of the form:
   - `label`: Label
   - `link`: URL or a dict
   - `attrs`: Dictionary of attributes (optional)
+- `omero_web_apps_ui_metadata_panes`: Items to be appended to `omero.web.ui.metadata_panes`
+- `omero_web_apps_config_append`: Dictionary of other key-value pairs to be appended
+- `omero_web_apps_config_set`: Dictionary of other key-value pairs to be set
+- `omero_web_apps_config_name`: The basename of the configuration file (`web/config/{{ omero_web_apps_config_name }}.omero`)
 
 
 Example

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,0 +1,31 @@
+---
+# defaults for omero-web-apps
+
+# The pip installable package
+omero_web_apps_package: []
+
+# The name of the web application, used for configuration
+omero_web_apps_name: []
+
+# Top links
+omero_web_apps_top_links: []
+
+# UI metadata panes
+omero_web_apps_ui_metadata_panes: []
+
+# Other list value properties (dict, append)
+omero_web_apps_config_append: {}
+
+# Other key value properties (dict, set)
+omero_web_apps_config_set: {}
+
+# The basename of the configuration file
+omero_web_apps_config_name: omero-web-apps
+
+
+######################################################################
+# Expert users only!
+######################################################################
+
+# The OMERO.web configuration directory
+omero_web_apps_omeroweb_config_dir: "{{ omero_common_basedir }}/web/config"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,10 +2,10 @@
 # defaults for omero-web-apps
 
 # The pip installable package
-omero_web_apps_package: []
+omero_web_apps_packages: []
 
 # The name of the web application, used for configuration
-omero_web_apps_name: []
+omero_web_apps_names: []
 
 # Top links
 omero_web_apps_top_links: []

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,9 +1,0 @@
----
-# Handler for omero-web
-
-- name: restart omero-web
-  become: yes
-  service:
-    name: omero-web
-    state: restarted
-  when: omero_systemd_setup

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,13 +1,15 @@
 galaxy_info:
   author: ome-devel@lists.openmicroscopy.org.uk
-  description: Install OMERO.web plugins
+  description: Install an OMERO.web plugin
   company: Open Microscopy Environment
   license: BSD
-  min_ansible_version: 2.1
+  min_ansible_version: 2.2
   platforms:
   - name: EL
     versions:
     - 7
   galaxy_tags: []
 
-dependencies: []
+dependencies:
+- name: openmicroscopy.omero-common
+  src: openmicroscopy.omero-common

--- a/molecule.yml
+++ b/molecule.yml
@@ -1,0 +1,30 @@
+---
+dependency:
+  name: galaxy
+  requirements_file: tests/requirements.yml
+
+driver:
+  name: docker
+
+vagrant:
+  platforms:
+    - name: centos7
+      box: centos/7
+  providers:
+    - name: virtualbox
+      type: virtualbox
+      options:
+        memory: 512
+        cpus: 1
+  instances:
+    - name: omero-web-apps
+
+docker:
+  containers:
+  - name: omero-web-apps
+    image: centos/systemd
+    image_version: latest
+    privileged: True
+
+verifier:
+  name: testinfra

--- a/playbook.yml
+++ b/playbook.yml
@@ -8,9 +8,9 @@
       omero_web_ice_version: "3.6"
 
     - role: ansible-role-omero-web-apps
-      omero_web_apps_package:
+      omero_web_apps_packages:
         - "omero-mapr==0.1.12"
-      omero_web_apps_name:
+      omero_web_apps_names:
         - omero_mapr
       omero_web_apps_top_links:
         - label: OMERO
@@ -46,4 +46,6 @@
                 - "openmicroscopy.org/mapr/gene/supplementary"
               label: "Gene supplementary"
       omero_web_apps_config_set:
-        example.key: example value
+        example.string: example value
+        example.boolean: True
+        example.integer: 2

--- a/playbook.yml
+++ b/playbook.yml
@@ -1,0 +1,49 @@
+---
+
+- hosts: all
+  roles:
+
+    - role: openmicroscopy.omero-web
+      omero_web_release: 5.3.0-m9
+      omero_web_ice_version: "3.6"
+
+    - role: ansible-role-omero-web-apps
+      omero_web_apps_package:
+        - "omero-mapr==0.1.12"
+      omero_web_apps_name:
+        - omero_mapr
+      omero_web_apps_top_links:
+        - label: OMERO
+          link:
+            viewname: webindex
+            query_string: { experimenter: -1 }
+          attrs:
+            title: Image Data Repository
+        - label: Genes
+          link:
+            viewname: maprindex_gene
+            query_string: { experimenter: -1 }
+          attrs:
+            title: Genes browser
+      omero_web_apps_config_append:
+        omero.web.mapr.config:
+          - menu: "gene"
+            config:
+              default:
+                - "Gene Symbol"
+              all:
+                - "Gene Symbol"
+                - "Gene Identifier"
+              ns:
+                - "openmicroscopy.org/mapr/gene"
+              label: "Gene"
+              case_sensitive: True
+          - menu: "genesupplementary"
+            config:
+              default: []
+              all: []
+              ns:
+                - "openmicroscopy.org/mapr/gene/supplementary"
+              label: "Gene supplementary"
+      omero_web_apps_config_set:
+        example.key: example value

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,70 +1,20 @@
 ---
 # tasks file for roles/omero-web-apps
 
-- name: omero web apps | omero location
-  set_fact:
-    omero_web_omero: "{{ omero_serverdir }}/{{ omero_server_symlink }}/bin/omero"
-
-- name: system pip | install webapp
+- name: omero web apps | install web-app
   become: yes
   pip:
     name: "{{ item }}"
     state: present
-  with_items: "{{ omero_web_app_packages | default([]) }}"
+  with_items: "{{ omero_web_apps_package }}"
   notify:
     - restart omero-web
 
-- name: omero web config | add application
+- name: omero web apps | add application web configuration
   become: yes
-  become_user: "{{ omero_system_user }}"
-  command: >
-    {{ omero_web_omero }} config append --set --report
-    omero.web.apps
-    {{ item | to_json | quote }}
-  register: out
-  changed_when: "'Changed:' in out.stdout"
-  with_items: "{{ omero_web_apps_add | default([]) }}"
-  notify:
-    - restart omero-web
-
-- name: omero web config | add top links
-  become: yes
-  become_user: "{{ omero_system_user }}"
-  command: >
-    {{ omero_web_omero }} config append --set --report
-    omero.web.ui.top_links
-    {{ [item.label, item.link, (item.attrs | default({}))] | to_json | quote }}
-  register: out
-  changed_when: "'Changed:' in out.stdout"
-  with_items: "{{ omero_web_app_add_top_links | default([]) }}"
-  notify:
-    - restart omero-web
-
-- name: omero web config | ui metadata panes
-  become: yes
-  become_user: "{{ omero_system_user }}"
-  command: >
-    {{ omero_web_omero }} config append --set --report
-    omero.web.ui.metadata_panes {{ item | to_json | quote }}
-  register: out
-  changed_when: "'Changed:' in out.stdout"
-  with_items: "{{ omero_web_ui_metadata_panes | default([]) }}"
-  notify:
-    - restart omero-web
-
-# This block iterates through OMERO config `key:value` pairs where
-# `value` is a list of items to be individually added using
-# `config append`
-- name: omero web config | additional config append
-  become: yes
-  become_user: "{{ omero_system_user }}"
-  command: >
-    {{ omero_web_omero }} config append --set --report
-    {{ item.0.key }} {{ item.1 | to_json | quote }}
-  register: out
-  changed_when: "'Changed:' in out.stdout"
-  with_subelements:
-  - "{{ omero_web_additional_config_append | default({}) }}"
-  - value
+  template:
+    dest: "{{ omero_web_apps_omeroweb_config_dir }}/{{ omero_web_apps_config_name }}.omero"
+    force: yes
+    src: omero-web-apps-omero.j2
   notify:
     - restart omero-web

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,7 +6,7 @@
   pip:
     name: "{{ item }}"
     state: present
-  with_items: "{{ omero_web_apps_package }}"
+  with_items: "{{ omero_web_apps_packages }}"
   notify:
     - restart omero-web
 

--- a/templates/omero-web-apps-omero.j2
+++ b/templates/omero-web-apps-omero.j2
@@ -1,0 +1,30 @@
+# {{ ansible_managed }}
+
+# add application
+{% for item in omero_web_apps_name %}
+config append -- omero.web.apps {{ item | to_json | quote }}
+{% endfor %}
+
+# add top links
+{% for item in omero_web_apps_top_links %}
+config append -- omero.web.ui.top_links {{ [item.label, item.link, (item.attrs | default({}))] | to_json | quote }}
+{% endfor %}
+
+# ui metadata panes
+{% for item in omero_web_apps_ui_metadata_panes %}
+config append -- omero.web.ui.metadata_panes {{ item | to_json | quote }}
+{% endfor %}
+
+# Other list value properties (append)
+{% for key in omero_web_apps_config_append %}
+config append -- {{ key | quote }} {{ omero_web_apps_config_append[key] | to_json | quote }}
+{% endfor %}
+
+# Other key value properties (set)
+{% for key in omero_web_apps_config_set %}
+config set -- {{ key | quote }} {{
+  ((omero_web_apps_config_set[key] | string) == omero_web_apps_config_set[key]) |
+  ternary(omero_web_apps_config_set[key], omero_web_apps_config_set[key] | to_json) |
+  quote
+}}
+{% endfor %}

--- a/templates/omero-web-apps-omero.j2
+++ b/templates/omero-web-apps-omero.j2
@@ -1,7 +1,7 @@
 # {{ ansible_managed }}
 
 # add application
-{% for item in omero_web_apps_name %}
+{% for item in omero_web_apps_names %}
 config append -- omero.web.apps {{ item | to_json | quote }}
 {% endfor %}
 

--- a/tests/inventory
+++ b/tests/inventory
@@ -1,1 +1,0 @@
-localhost

--- a/tests/requirements.yml
+++ b/tests/requirements.yml
@@ -1,0 +1,6 @@
+- name: openmicroscopy.omero-common
+  src:  https://github.com/openmicroscopy/ansible-role-omero-common.git
+- name: openmicroscopy.omego
+  src:  https://github.com/openmicroscopy/ansible-role-omego.git
+- name: openmicroscopy.omero-web
+  src:  https://github.com/manics/ansible-role-omero-web.git

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,5 +1,0 @@
----
-- hosts: localhost
-  remote_user: root
-  roles:
-  - role: ansible-role-omero-web-apps

--- a/tests/test_default.py
+++ b/tests/test_default.py
@@ -1,0 +1,86 @@
+import testinfra.utils.ansible_runner
+import json
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    '.molecule/ansible_inventory').get_hosts('all')
+
+OMERO = '/opt/omero/web/OMERO.web/bin/omero'
+
+
+def assert_jcfg(Command, Sudo, key, value, isjson):
+    with Sudo('omeroweb'):
+        cfg = Command.check_output("%s config get %s", OMERO, key)
+    if isjson:
+        cfg = json.loads(cfg)
+    assert cfg == value
+
+
+def test_example_key(Command, Sudo):
+    assert_jcfg(Command, Sudo, 'example.key', 'example value', False)
+
+
+def test_omero_web_apps(Command, Sudo):
+    assert_jcfg(Command, Sudo, 'omero.web.apps', ["omero_mapr"], True)
+
+
+def test_omero_web_mapr_config(Command, Sudo):
+    expected = [
+        [
+            {
+                "menu": "gene", "config": {
+                    "default": ["Gene Symbol"],
+                    "case_sensitive": True,
+                    "all": ["Gene Symbol", "Gene Identifier"],
+                    "ns": ["openmicroscopy.org/mapr/gene"],
+                    "label": "Gene"
+                }
+            },
+            {
+                "menu": "genesupplementary",
+                "config": {
+                    "default": [],
+                    "all": [],
+                    "ns": ["openmicroscopy.org/mapr/gene/supplementary"],
+                    "label": "Gene supplementary"
+                }
+            }
+        ]
+    ]
+    assert_jcfg(Command, Sudo, 'omero.web.mapr.config', expected, True)
+
+
+def test_omero_web_ui_toplinks(Command, Sudo):
+    expected = [
+        [
+            "Data",
+            "webindex",
+            {"title": "Browse Data via Projects, Tags etc"}
+        ],
+        [
+            "History",
+            "history",
+            {"title": "History"}
+        ],
+        [
+            "Help",
+            "http://help.openmicroscopy.org/",
+            {"target": "new", "title": "Open OMERO user guide in a new tab"}
+        ],
+        [
+            "OMERO",
+            {
+                "query_string": {"experimenter": -1},
+                "viewname": "webindex"
+            },
+            {"title": "Image Data Repository"}
+        ],
+        [
+            "Genes",
+            {
+                "query_string": {"experimenter": -1},
+                "viewname": "maprindex_gene"
+            },
+            {"title": "Genes browser"}
+        ]
+    ]
+    assert_jcfg(Command, Sudo, 'omero.web.ui.top_links', expected, True)

--- a/tests/test_default.py
+++ b/tests/test_default.py
@@ -1,5 +1,6 @@
 import testinfra.utils.ansible_runner
 import json
+import pytest
 
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
     '.molecule/ansible_inventory').get_hosts('all')
@@ -15,8 +16,13 @@ def assert_jcfg(Command, Sudo, key, value, isjson):
     assert cfg == value
 
 
-def test_example_key(Command, Sudo):
-    assert_jcfg(Command, Sudo, 'example.key', 'example value', False)
+@pytest.mark.parametrize("key,value", [
+    ('example.string', 'example value'),
+])
+#    ('example.boolean', True),
+#    ('example.integer', 2),
+def test_example_config(Command, Sudo, key, value):
+    assert_jcfg(Command, Sudo, key, value, False)
 
 
 def test_omero_web_apps(Command, Sudo):


### PR DESCRIPTION
This takes advantage of the new templating config files in https://github.com/openmicroscopy/ansible-role-omero-web

I was undecided on whether to keep maintaining this role, to drop it, or to rename it. It's current two tasks are:
- `pip install <omero-app>`: (Could easily be accomplished elsewhere)
- Create a configuration file in `/opt/omero/web/config/omero-web-apps.omero`: Fairly easy to accomplish elsewhere, though this PR does add the ability to pass json values as YAML objects instead of having to manually construct a JSON string.

This is a breaking change, though this role has always been considered under development. Does anyone have thoughts on whether to maintain or drop this role?