### PR TITLE
Handle multiple append values for same key correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ All variables are optional:
   - `link`: URL or a dict
   - `attrs`: Dictionary of attributes (optional)
 - `omero_web_apps_ui_metadata_panes`: Items to be appended to `omero.web.ui.metadata_panes`
-- `omero_web_apps_config_append`: Dictionary of other key-value pairs to be appended
+- `omero_web_apps_config_append`: Dictionary of other key-[list of values] pairs to be appended (multiple values can be appended to the same key)
 - `omero_web_apps_config_set`: Dictionary of other key-value pairs to be set
 - `omero_web_apps_config_name`: The basename of the configuration file (`web/config/{{ omero_web_apps_config_name }}.omero`)
 

--- a/playbook.yml
+++ b/playbook.yml
@@ -4,12 +4,11 @@
   roles:
 
     - role: openmicroscopy.omero-web
-      omero_web_release: 5.3
       omero_web_ice_version: "3.6"
 
     - role: ansible-role-omero-web-apps
       omero_web_apps_packages:
-        - "omero-mapr==0.1.12"
+        - omero-mapr
       omero_web_apps_names:
         - omero_mapr
       omero_web_apps_top_links:

--- a/templates/omero-web-apps-omero.j2
+++ b/templates/omero-web-apps-omero.j2
@@ -17,7 +17,9 @@ config append -- omero.web.ui.metadata_panes {{ item | to_json | quote }}
 
 # Other list value properties (append)
 {% for key in omero_web_apps_config_append %}
-config append -- {{ key | quote }} {{ omero_web_apps_config_append[key] | to_json | quote }}
+{%   for value in omero_web_apps_config_append[key] %}
+config append -- {{ key | quote }} {{ value | to_json | quote }}
+{%   endfor %}
 {% endfor %}
 
 # Other key value properties (set)

--- a/tests/test_default.py
+++ b/tests/test_default.py
@@ -31,26 +31,24 @@ def test_omero_web_apps(Command, Sudo):
 
 def test_omero_web_mapr_config(Command, Sudo):
     expected = [
-        [
-            {
-                "menu": "gene", "config": {
-                    "default": ["Gene Symbol"],
-                    "case_sensitive": True,
-                    "all": ["Gene Symbol", "Gene Identifier"],
-                    "ns": ["openmicroscopy.org/mapr/gene"],
-                    "label": "Gene"
-                }
-            },
-            {
-                "menu": "genesupplementary",
-                "config": {
-                    "default": [],
-                    "all": [],
-                    "ns": ["openmicroscopy.org/mapr/gene/supplementary"],
-                    "label": "Gene supplementary"
-                }
+        {
+            "menu": "gene", "config": {
+                "default": ["Gene Symbol"],
+                "case_sensitive": True,
+                "all": ["Gene Symbol", "Gene Identifier"],
+                "ns": ["openmicroscopy.org/mapr/gene"],
+                "label": "Gene"
             }
-        ]
+        },
+        {
+            "menu": "genesupplementary",
+            "config": {
+                "default": [],
+                "all": [],
+                "ns": ["openmicroscopy.org/mapr/gene/supplementary"],
+                "label": "Gene supplementary"
+            }
+        }
     ]
     assert_jcfg(Command, Sudo, 'omero.web.mapr.config', expected, True)
 

--- a/tests/test_default.py
+++ b/tests/test_default.py
@@ -67,7 +67,7 @@ def test_omero_web_ui_toplinks(Command, Sudo):
         ],
         [
             "Help",
-            "http://help.openmicroscopy.org/",
+            "https://help.openmicroscopy.org/",
             {"target": "new", "title": "Open OMERO user guide in a new tab"}
         ],
         [


### PR DESCRIPTION
When multiple values are appended to an OMERO property `config append` must be run separately for each value.

This should fix the error in https://github.com/IDR/deployment/pull/133#issuecomment-422333778

Tag: `0.1.1`