### PR TITLE
Disable role when OMERO.web is deployed on Python3

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This is primarily aimed to help with the configuration of OMERO.web applications
 This role only works with OMERO.web 5.3+ due to changes in the configuration handling.
 
 This role ***does not*** support OMERO.web running under Python 3.
-All functionality is being merged into the [ome.omero_web](https://galaxy.ansible.com/ome/omero_web) role for Python 3 deployments.
+All functionality is included in the [ome.omero_web](https://galaxy.ansible.com/ome/omero_web) role for OMERO.web 5.6+ Python 3 deployments.
 Parameter names are unchanged.
 
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ Additional OMERO.web configuration.
 This is primarily aimed to help with the configuration of OMERO.web applications/plugins, but can also be used to manage standard OMERO.web configuration properties.
 This role only works with OMERO.web 5.3+ due to changes in the configuration handling.
 
+This role ***does not*** support OMERO.web running under Python 3.
+All functionality is being merged into the [ome.omero_web](https://galaxy.ansible.com/ome/omero_web) role for Python 3 deployments.
+Parameter names are unchanged.
+
 
 Dependencies
 ------------

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,11 @@
 ---
 # tasks file for roles/omero-web-apps
 
+- name: omero web apps | check omero web python
+  fail:
+    msg: This role has been merged into ome.omero_web for Python3
+  when: 'omero_web_python3 | default(False)'
+
 - name: omero web apps | install web-app
   become: true
   pip:


### PR DESCRIPTION
~~The virtualenv path and system-site-packages depends on whether the OMERO.web role is using Python 2 or 3.~~

0.2.0 has been merged into https://github.com/ome/ansible-role-omero-web/pull/26 for Python 3.
Benefits:
- Faster deployment
- Better error recovery when there is a configuration error: Previously you'd deploy `ome.omero_web` before this role. If you made a configuration error in this role that caused OMERO.web to fail you'd expect to be able to modify this configuration and rerun the playbook. However since `ome.omero_web` is called first it will attempt to start omero-web before the config fixes in this role are deployed, and will fail.